### PR TITLE
Check xfs_info of device and not of mountpoint

### DIFF
--- a/tasks/create_fs.yml
+++ b/tasks/create_fs.yml
@@ -4,7 +4,7 @@
 - name: create_fs | check already converted
   # at least xfs is executed twice if the partition has changed in the meantime
   # then it tries to recreate the fs on the mounted fs which indeed fails...
-  shell: "xfs_info {{ lv.mntp }} | grep -c 'ftype=1'"
+  shell: "xfs_info /dev/{{ vg.vgname }}/{{ lv.lvname }} | grep -c 'ftype=1'"
   become: yes
   register: mountedxfs
   ignore_errors: true


### PR DESCRIPTION
xfs_info should check the device and not the mountpoint. On the first run, the mountpoint could be part of an underlying filesystem (e.g. /). Hence, xfs_info checks if the underlying filesystem is converted, but not if the current device is already converted.